### PR TITLE
Throw exception when access token cannot be retrieved

### DIFF
--- a/Model/Client.php
+++ b/Model/Client.php
@@ -154,8 +154,9 @@ class Client extends ContainerAware
 
             $response = json_decode($this->httpAdapter->postContent(self::URL, $headers, $content));
 
-			if(isset($response->error))
-				throw new \ErrorException("Failed to retrieve access token, google responsed: " .$response->error);
+            if(isset($response->error)) {
+                throw new \ErrorException("Failed to retrieve access token, google responsed: " .$response->error);
+            }
 
             $this->accessToken = $response->access_token;
         }

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -154,6 +154,9 @@ class Client extends ContainerAware
 
             $response = json_decode($this->httpAdapter->postContent(self::URL, $headers, $content));
 
+			if(isset($response->error))
+				throw new \ErrorException("Failed to retrieve access token, google responsed: " .$response->error);
+
             $this->accessToken = $response->access_token;
         }
 


### PR DESCRIPTION
I struggled a little bit because PHP was throwing this error `Notice: Undefined property: stdClass::$access_token` so it's better to throw an exception to actually know what happened.
