### PR TITLE
[Query] Set max-results to 10.000 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # CHANGELOG
 
+### 1.0.1 (????-??-??)
+
+* ab7d8b3 - [Query] Set max-results to 10.000 by default
+
 ### 1.0.0 (2013-04-25)

--- a/Model/Query.php
+++ b/Model/Query.php
@@ -71,7 +71,7 @@ class Query
         $this->sorts = array();
         $this->filters = array();
         $this->startIndex = 1;
-        $this->maxResults = 1000;
+        $this->maxResults = 10000;
         $this->prettyPrint = false;
     }
 

--- a/Tests/Model/QueryTest.php
+++ b/Tests/Model/QueryTest.php
@@ -55,7 +55,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->query->hasFilters());
         $this->assertFalse($this->query->hasSegment());
         $this->assertSame(1, $this->query->getStartIndex());
-        $this->assertSame(1000, $this->query->getMaxResults());
+        $this->assertSame(10000, $this->query->getMaxResults());
         $this->assertFalse($this->query->getPrettyPrint());
         $this->assertFalse($this->query->hasCallback());
     }


### PR DESCRIPTION
This PR fixes a "bug" in the `Query` about default `max-results` value. The value was 1.000 but according to the [spec](https://developers.google.com/analytics/devguides/reporting/core/v3/reference#maxResults), 1.000 is the default value if you don't provide a value. The Google Analytics service can return a maximum of 10.000 rows, so, I use now this value as default value.

IMO, the bundle should try (by default) to reduce the number of request done when we fetch a big dataset without having to take care about the `max-results`. Without this fix, it is not the case...
Additionally, if devs use the current version to fetch a big dataset through a loop & without set the `max-results` explictly, I really recommend them to upgrade in order to reduce the number of request done.

ping @tmartin :kiss:
