### PR TITLE
[Client] Make Google Analytics url configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('http_adapter')
                     ->defaultValue('widop_http_adapter.curl')
                 ->end()
+                ->scalarNode('service_url')
+                    ->defaultValue('https://accounts.google.com/o/oauth2/token')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/WidopGoogleAnalyticsExtension.php
+++ b/DependencyInjection/WidopGoogleAnalyticsExtension.php
@@ -35,12 +35,15 @@ class WidopGoogleAnalyticsExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('widop_google_analytics.client_id', $config['client_id']);
-        $container->setParameter('widop_google_analytics.profile_id', $config['profile_id']);
-        $container->setParameter('widop_google_analytics.private_key_file', $config['private_key_file']);
-
         $container
             ->getDefinition('widop_google_analytics.client')
-            ->addArgument(new Reference($config['http_adapter']));
+            ->addArgument($config['client_id'])
+            ->addArgument($config['private_key_file'])
+            ->addArgument(new Reference($config['http_adapter']))
+            ->addArgument($config['service_url']);
+
+        $container
+            ->getDefinition('widop_google_analytics.query')
+            ->addArgument($config['profile_id']);
     }
 }

--- a/Model/Client.php
+++ b/Model/Client.php
@@ -20,9 +20,6 @@ use Widop\HttpAdapterBundle\Model\HttpAdapterInterface;
  */
 class Client
 {
-    /** @const The google OAuth Rest URL. */
-    const URL = 'https://accounts.google.com/o/oauth2/token';
-
     /** @const The google OAuth scope. */
     const SCOPE = 'https://www.googleapis.com/auth/analytics.readonly';
 
@@ -36,6 +33,9 @@ class Client
     protected $httpAdapter;
 
     /** @var string */
+    protected $url;
+
+    /** @var string */
     protected $accessToken;
 
     /**
@@ -44,12 +44,14 @@ class Client
      * @param string                                              $clientId       The client ID.
      * @param string                                              $privateKeyFile The absolute private key file path.
      * @param \Widop\HttpAdapterBundle\Model\HttpAdapterInterface $httpAdapter    The http adapter.
+     * @param string                                              $url            The google analytics service url.
      */
-    public function __construct($clientId, $privateKeyFile, HttpAdapterInterface $httpAdapter)
+    public function __construct($clientId, $privateKeyFile, HttpAdapterInterface $httpAdapter, $url)
     {
         $this->setClientId($clientId);
         $this->setPrivateKeyFile($privateKeyFile);
         $this->setHttpAdapter($httpAdapter);
+        $this->setUrl($url);
     }
 
     /**
@@ -72,7 +74,7 @@ class Client
     public function setClientId($clientId)
     {
         $this->clientId = $clientId;
-        
+
         return $this;
     }
 
@@ -104,7 +106,7 @@ class Client
         }
 
         $this->privateKeyFile = $privateKeyFile;
-        
+
         return $this;
     }
 
@@ -128,7 +130,31 @@ class Client
     public function setHttpAdapter(HttpAdapterInterface $httpAdapter)
     {
         $this->httpAdapter = $httpAdapter;
-        
+
+        return $this;
+    }
+
+    /**
+     * Gets the google analytics service url.
+     *
+     * @return string The google analytics service url.
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Sets the google analytics service url.
+     *
+     * @param string $url The google analytics service url.
+     *
+     * @return \Widop\GoogleAnalyticsBundle\Model\Client The client.
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
         return $this;
     }
 
@@ -149,7 +175,7 @@ class Client
                 'assertion'      => $this->generateJsonWebToken(),
             );
 
-            $response = json_decode($this->httpAdapter->postContent(self::URL, $headers, $content));
+            $response = json_decode($this->httpAdapter->postContent($this->url, $headers, $content));
 
             if (isset($response->error)) {
                 throw new \Exception(sprintf('Failed to retrieve access token (%s).', $response->error));
@@ -178,7 +204,7 @@ class Client
                 array(
                     'iss'   => $this->clientId,
                     'scope' => self::SCOPE,
-                    'aud'   => self::URL,
+                    'aud'   => $this->url,
                     'exp'   => $exp->getTimestamp(),
                     'iat'   => $iat->getTimestamp(),
                 )

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,17 +12,12 @@
     </parameters>
 
     <services>
-        <service id="widop_google_analytics.client" class="%widop_google_analytics.client.class%">
-            <argument>%widop_google_analytics.client_id%</argument>
-            <argument>%widop_google_analytics.private_key_file%</argument>
-        </service>
-
         <service id="widop_google_analytics" class="%widop_google_analytics.class%">
             <argument type="service" id="widop_google_analytics.client" />
         </service>
 
-        <service id="widop_google_analytics.query" class="%widop_google_analytics.query.class%">
-            <argument>%widop_google_analytics.profile_id%</argument>
-        </service>
+        <service id="widop_google_analytics.client" class="%widop_google_analytics.client.class%" />
+
+        <service id="widop_google_analytics.query" class="%widop_google_analytics.query.class%" />
     </services>
 </container>

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -16,7 +16,7 @@
 The `WidopGoogleAnalyticsBundle` can be configured quite easily, and of course you can change the configuration given
 your environment (dev, test, prod):
 
-``` yml
+``` yaml
 # app/config/config.yml
 widop_google_analytics:
     client_id:        "XXXXXXXXXXXX@developer.gserviceaccount.com"
@@ -28,6 +28,14 @@ widop_google_analytics:
 The `client_id`, `profile_id` and `private_key_file` parameters are mandatory while the `http_adapter` is optionnal.
 By default, this parameter is set to `widop_http_adapter.curl`. If you want to change the http adapter you can take a
 look at the [WidopHttpAdapterBundle](https://github.com/widop/WidopHttpAdapterBundle) documentation.
+
+For testing purpose, you can change the google analytics url used internally by the bundle to fetch you datas:
+
+``` yaml
+# app/config/config_test.yml
+widop_google_analytics:
+    service_url: http://your-own-url
+```
 
 ## The client
 

--- a/Tests/DependencyInjection/AbstractWidopGoogleAnalyticsExtensionTest.php
+++ b/Tests/DependencyInjection/AbstractWidopGoogleAnalyticsExtensionTest.php
@@ -61,6 +61,7 @@ abstract class AbstractWidopGoogleAnalyticsExtensionTest extends \PHPUnit_Framew
         $googleAnalytics = $this->container->get('widop_google_analytics');
 
         $this->assertInstanceOf('Widop\GoogleAnalyticsBundle\Model\GoogleAnalyticsService', $googleAnalytics);
+        $this->assertSame('https://accounts.google.com/o/oauth2/token', $googleAnalytics->getClient()->getUrl());
         $this->assertSame('client_id', $googleAnalytics->getClient()->getClientId());
         $this->assertSame('certificate.p12', substr($googleAnalytics->getClient()->getPrivateKeyFile(), -15));
         $this->assertSame('curl', $googleAnalytics->getClient()->getHttpAdapter()->getName());
@@ -75,6 +76,17 @@ abstract class AbstractWidopGoogleAnalyticsExtensionTest extends \PHPUnit_Framew
 
         $this->assertInstanceOf('Widop\GoogleAnalyticsBundle\Model\Query', $query);
         $this->assertSame('profile_id', $query->getIds());
+    }
+
+    public function testServiceUrl()
+    {
+        $this->loadConfiguration($this->container, 'service_url');
+        $this->container->compile();
+
+        $googleAnalytics = $this->container->get('widop_google_analytics');
+
+        $this->assertInstanceOf('Widop\GoogleAnalyticsBundle\Model\GoogleAnalyticsService', $googleAnalytics);
+        $this->assertSame('https://foo', $googleAnalytics->getClient()->getUrl());
     }
 
     /**

--- a/Tests/DependencyInjection/Fixtures/Yaml/service_url.yml
+++ b/Tests/DependencyInjection/Fixtures/Yaml/service_url.yml
@@ -1,0 +1,6 @@
+widop_google_analytics:
+    client_id:        "client_id"
+    profile_id:       "profile_id"
+    private_key_file: "%bundle.dir%/Tests/Fixtures/certificate.p12"
+    http_adapter:     "widop_http_adapter.curl"
+    service_url:      "https://foo"

--- a/Tests/Model/ClientTest.php
+++ b/Tests/Model/ClientTest.php
@@ -29,6 +29,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     /** @var string */
     protected $privateKeyFile;
 
+    /** @var string */
+    protected $url;
+
     /** @var \Widop\HttpAdapterBundle\Model\HttpAdapterInterface */
     protected $httpAdapterMock;
 
@@ -40,8 +43,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->clientId = 'client_id';
         $this->privateKeyFile = __DIR__.'/../Fixtures/certificate.p12';
         $this->httpAdapterMock = $this->getMock('Widop\HttpAdapterBundle\Model\HttpAdapterInterface');
+        $this->url = 'https://foo';
 
-        $this->client = new Client($this->clientId, $this->privateKeyFile, $this->httpAdapterMock);
+        $this->client = new Client($this->clientId, $this->privateKeyFile, $this->httpAdapterMock, $this->url);
     }
 
     /**
@@ -53,6 +57,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         unset($this->clientId);
         unset($this->privateKeyFile);
         unset($this->httpAdapterMock);
+        unset($this->url);
     }
 
     public function testDefaultState()
@@ -60,6 +65,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->clientId, $this->client->getClientId());
         $this->assertSame($this->privateKeyFile, $this->client->getPrivateKeyFile());
         $this->assertSame($this->httpAdapterMock, $this->client->getHttpAdapter());
+        $this->assertSame($this->url, $this->client->getUrl());
     }
 
     public function testAccessToken()
@@ -72,7 +78,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('postContent')
             ->with(
-                $this->equalTo('https://accounts.google.com/o/oauth2/token'),
+                $this->equalTo($this->url),
                 $this->equalTo(array('Content-Type' => 'application/x-www-form-urlencoded'))
             )
             ->will($this->returnValue(json_encode(array('access_token' => 'token'))));


### PR DESCRIPTION
This PR fixes #18 by allowing to define your own google analytics service url in your configuration.

@marmotz Does it fix your issue?
